### PR TITLE
check in bad workflow

### DIFF
--- a/.github/workflows/checkout.yml
+++ b/.github/workflows/checkout.yml
@@ -1,0 +1,14 @@
+name: Checkout code
+on:
+    workflow_dispatch:
+
+jobs:
+    checkout:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+            - name: Checkout code
+              uses: actions/checkout@v3
+            - name: Checkout code
+              uses: actions/checkout@v2


### PR DESCRIPTION
This PR check is failing because it includes a workflow file using old/deprecated node versions.